### PR TITLE
Added schema for fct_game, fixed code for ref to dim_opening

### DIFF
--- a/models/marts/fct_game.sql
+++ b/models/marts/fct_game.sql
@@ -1,19 +1,5 @@
 with
 
-columns_to_join_on as (
-  select
-    game_id,
-    opening_name,
-    opponent_id,
-    my_result,
-    result_method,
-    colour,
-    time_class,
-    time_control
-
-  from {{ ref("int_game_information") }}
-),
-
 joining_dims as (
   select
     cols.game_id,
@@ -21,9 +7,24 @@ joining_dims as (
     dim_opening.opening_sid,
     dim_opponent.opponent_sid,
     dim_result.result_sid,
-    dim_time_control.time_control_sid
+    dim_time_control.time_control_sid,
+    cols.my_rating,
+    cols.opponent_rating,
+    cols.my_accuracy,
+    cols.opponent_accuracy,
+    cols.move_number_reached,
+    cols.total_moves,
+    datetime_diff(
+      cols.end_timestamp_utc,
+      cols.start_timestamp_utc,
+      second
+    )                  as game_length,
+    lead(cols.my_rating, 1) over (
+      partition by cols.source
+      order by cols.start_timestamp_utc
+    ) - cols.my_rating as rating_change
 
-  from columns_to_join_on as cols
+  from {{ ref("int_game_information") }} as cols
 
   left join {{ ref("dim_game") }} as dim_game
     on cols.game_id = dim_game.game_id
@@ -33,6 +34,10 @@ joining_dims as (
     = trim(split(cols.opening_name, ':')[safe_offset(0)])
     and coalesce(dim_opening.opening_variation, '')
     = coalesce(trim(split(cols.opening_name, ':')[safe_offset(1)]), '')
+    and dim_opening.white_first_move
+    = cols.moves[safe_offset(0)]
+    and dim_opening.black_first_move
+    = cols.moves[safe_offset(1)]
 
   left join {{ ref("dim_opponent") }} as dim_opponent
     on cols.opponent_id = dim_opponent.opponent_id
@@ -43,28 +48,6 @@ joining_dims as (
 
   left join {{ ref("dim_time_control") }} as dim_time_control
     on cols.time_control = dim_time_control.time_control
-),
-
-fact_columns as (
-  select
-    game_id,
-    my_rating,
-    opponent_rating,
-    my_accuracy,
-    opponent_accuracy,
-    move_number_reached,
-    total_moves,
-    datetime_diff(
-      end_timestamp_utc,
-      start_timestamp_utc,
-      second
-    )             as game_length,
-    lead(my_rating, 1) over (
-      partition by source
-      order by start_timestamp_utc
-    ) - my_rating as rating_change
-
-  from {{ ref("int_game_information") }}
 ),
 
 fct_game as (
@@ -83,10 +66,7 @@ fct_game as (
     game_length,
     rating_change
 
-  from fact_columns
-
-  inner join joining_dims
-    on fact_columns.game_id = joining_dims.game_id
+  from joining_dims
 )
 
 select * from fct_game

--- a/models/marts/fct_game.yml
+++ b/models/marts/fct_game.yml
@@ -1,0 +1,70 @@
+models:
+  - name: fct_game
+    description: fact table containing statistics about a game such as ratings, accuracies, game length etc
+    config:
+      contract:
+        enforced: true
+    columns:
+      - name: game_sid
+        description: unique surrogate key to identify each game (ref to dim_game.game_sid)
+        constraints:
+          - type: primary_key
+          - type: foreign_key
+        data_tests:
+          - unique
+          - not_null
+          - relationships:
+              field: game_sid
+              to: ref('dim_game')
+      - name: opening_sid
+        description: (ref to dim_opening.opening_sid)
+        constraints:
+          - type: foreign_key
+        data_tests:
+          - not_null
+          - relationships:
+              field: opening_sid
+              to: ref('dim_opening')
+      - name: time_control_sid
+        description: (ref to dim_time_control.time_control_sid)
+        constraints:
+          - type: foreign_key
+        data_tests:
+          - not_null
+          - relationships:
+              field: time_control_sid
+              to: ref('dim_time_control')
+      - name: opponent_sid
+        description: (ref to dim_opponent.opponent_sid)
+        constraints:
+          - type: foreign_key
+        data_tests:
+          - not_null
+          - relationships:
+              field: opponent_sid
+              to: ref('dim_opponent')
+      - name: result_sid
+        description: (ref to dim_result.result_sid)
+        constraints:
+          - type: foreign_key
+        data_tests:
+          - not_null
+          - relationships:
+              field: result_sid
+              to: ref('dim_result')
+      - name: my_rating
+        description: my elo rating on the platform at the start of the game
+      - name: opponent_rating
+        description: opponent's elo rating on the platform at the start of the game
+      - name: my_accuracy
+        description: my accuracy as calculated by the platform through use of an engine
+      - name: opponent_accuracy
+        description: opponent's accuracy as calculated by the platform through use of an engine
+      - name: move_number_reached
+        description: e.g. if white and black played 42 moves each (or white 42, black 41) -> 42
+      - name: total_moves
+        description: e.g. if white and black played 42 and 41 moves -> 83
+      - name: game_length
+        description: the duration the game lasted in seconds
+      - name: rating_change
+        description: my rating after the game ends (and my rating at the start of the next game on the same platform)


### PR DESCRIPTION
Added full schema for `fct_game` in `fct_game.yml` including
- reference to foreign keys in dim tables, ensuring referential integrity
- column descriptions
- primary and foreign key constraints

Fixed logic in join of `dim_opening` to `fct_game`: Openings have same names but with different white and black first moves, as the same opening can be reached with different move orders. The uniqueness is specified with the first moves for each colour.
Added white and black first moves in join.